### PR TITLE
Update Mattermost - inc IPv6 support

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+turnkey-mattermost-17.2 (1) turnkey; urgency=low
+
+  * Updated Mattermost to latest upstream: v7.7.1.
+
+  * Add IPv6 support - closes #1800.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Tue, 14 Feb 2023 05:19:27 +0000
+
 turnkey-mattermost-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/overlay/etc/nginx/sites-available/mattermost
+++ b/overlay/etc/nginx/sites-available/mattermost
@@ -1,10 +1,12 @@
 server {
     listen 80;
+    listen [::]:80;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
+    listen [::]:443 ssl;
     include /etc/nginx/snippets/ssl.conf;
 
     location / {


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1800